### PR TITLE
chore(build): use the official _site folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-docs
+_site
 Gemfile.lock
 .sass-cache
 .jekyll-metadata

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script: ./cibuild
 deploy:
   provider: pages
   skip_cleanup: true
+  local_dir: _site
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   on:
     branch: master

--- a/_config.yml
+++ b/_config.yml
@@ -20,8 +20,6 @@ description: > # this means to ignore newlines until "baseurl:"
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
-destination: docs/
-
 # Build settings
 markdown: kramdown
 theme: minima


### PR DESCRIPTION
<img width=693 src=https://cloud.githubusercontent.com/assets/730511/25147089/8849477c-2476-11e7-9e2f-79901bc536db.gif>


---

I think there is a confusion between how Github handles the docs folder on the master branch and how travis can deploy whatever folder to a gh-pages branch so Github just serve the gh-pages branch.