### PR TITLE
doc(README): removing last standing Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Identique à la proposition mais avec le tag "Demande".
 
 Enjoy !
 
-## Le site web [![Master branch build status](https://travis-ci.org/Sfeir/bouffe-front.svg?branch=master)](https://travis-ci.org/Sfeir/bouffe-front)
+## Le site web
 
 Pour garder une trace des présentations faites, les bouffes front ont un site !
 


### PR DESCRIPTION
<img width=693 src=https://cloud.githubusercontent.com/assets/730511/25208168/1995403a-2573-11e7-8ceb-4412e4b28477.gif >



---

Following #50